### PR TITLE
Add support for adc in the g0 and f0 build

### DIFF
--- a/platform/stm32f0xx/CMakeLists.txt
+++ b/platform/stm32f0xx/CMakeLists.txt
@@ -67,6 +67,7 @@ target_sources(
         # build specs
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/platform-library/stm32f0xx/system/system_stm32f0xx.c>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/platform-library/stm32f0xx/hal/stm32f0xx_ll_utils.c>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/platform-library/stm32f0xx/hal/stm32f0xx_ll_adc.c>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/platform-library/stm32f0xx/hal/stm32f0xx_ll_dma.c>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/platform-library/stm32f0xx/hal/stm32f0xx_ll_exti.c>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/platform-library/stm32f0xx/hal/stm32f0xx_ll_gpio.c>

--- a/platform/stm32g0xx/CMakeLists.txt
+++ b/platform/stm32g0xx/CMakeLists.txt
@@ -67,6 +67,7 @@ target_sources(
         # build specs
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/platform-library/stm32g0xx/system/system_stm32g0xx.c>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/platform-library/stm32g0xx/hal/stm32g0xx_ll_utils.c>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/platform-library/stm32g0xx/hal/stm32g0xx_ll_adc.c>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/platform-library/stm32g0xx/hal/stm32g0xx_ll_dma.c>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/platform-library/stm32g0xx/hal/stm32g0xx_ll_exti.c>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/platform-library/stm32g0xx/hal/stm32g0xx_ll_gpio.c>


### PR DESCRIPTION
The core library for platform doesn't include the adc.c file in the build. 
This PR adds references for stm32f0xx and stm32g0xx